### PR TITLE
[WIP] - Update logrus dependency

### DIFF
--- a/practice/05-logger/main.go
+++ b/practice/05-logger/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/06-dependencies/main.go
+++ b/practice/06-dependencies/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/07-config/glide.lock
+++ b/practice/07-config/glide.lock
@@ -1,12 +1,14 @@
-hash: 52d732bbcddeae6f48f49fb3790a384274ad7bde41204b99743afc72b986e0ee
-updated: 2017-07-21T07:44:54.25932038+03:00
+hash: 6019f46ae05656f078e95642a58d163bf1c03f8f2786be70566489d2360abe2f
+updated: 2019-06-20T11:11:56.338913-05:00
 imports:
 - name: github.com/julienschmidt/httprouter
-  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 26a05976f9bf5c3aa992cc20e8588c359418ee58
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
+- name: github.com/sirupsen/logrus
+  version: 2a22dbedbad1fd454910cd1f44f210ef90c28464
 - name: golang.org/x/sys
-  version: 1e99a4f9d247b28c670884b9a8d6801f39a47b77
+  version: b47fdc937951267e2d980171881317deea47f29b
   subpackages:
   - unix
 testImports: []

--- a/practice/07-config/glide.yaml
+++ b/practice/07-config/glide.yaml
@@ -1,6 +1,4 @@
-package: github.com/rumyantseva/production-ready-microservices/practice/07-config
+package: github.com/shekodn/production-ready-microservices/practice/07-config
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^1.0.2
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+- package: github.com/sirupsen/logrus

--- a/practice/07-config/main.go
+++ b/practice/07-config/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/08-container/glide.lock
+++ b/practice/08-container/glide.lock
@@ -1,12 +1,14 @@
-hash: 52d732bbcddeae6f48f49fb3790a384274ad7bde41204b99743afc72b986e0ee
-updated: 2017-07-21T07:44:54.25932038+03:00
+hash: f20cc0284c7ecc738aad869f9c7fdcb548d4ae912454b7517b466f20e8c20bd9
+updated: 2019-06-20T11:17:08.238915-05:00
 imports:
 - name: github.com/julienschmidt/httprouter
-  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 348b672cd90d8190f8240323e372ecd1e66b59dc
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
+- name: github.com/sirupsen/logrus
+  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
 - name: golang.org/x/sys
-  version: 1e99a4f9d247b28c670884b9a8d6801f39a47b77
+  version: b47fdc937951267e2d980171881317deea47f29b
   subpackages:
   - unix
 testImports: []

--- a/practice/08-container/glide.yaml
+++ b/practice/08-container/glide.yaml
@@ -1,6 +1,4 @@
-package: github.com/rumyantseva/production-ready-microservices/practice/08-container
+package: github.com/shekodn/production-ready-microservices/practice/08-container
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^1.0.2
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+- package: github.com/sirupsen/logrus

--- a/practice/08-container/main.go
+++ b/practice/08-container/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/09-versioning/glide.lock
+++ b/practice/09-versioning/glide.lock
@@ -1,12 +1,18 @@
-hash: 52d732bbcddeae6f48f49fb3790a384274ad7bde41204b99743afc72b986e0ee
-updated: 2017-07-21T07:44:54.25932038+03:00
+hash: bc8bde7cffd095c38776eb10265e0011d5579f33a12ed606670bf18c73404115
+updated: 2019-06-20T11:27:37.810487-05:00
 imports:
 - name: github.com/julienschmidt/httprouter
-  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 348b672cd90d8190f8240323e372ecd1e66b59dc
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
+- name: github.com/rumyantseva/production-ready-microservices
+  version: 759ce485b6a1155db8a13b878c1e8ca87ff27607
+  subpackages:
+  - practice/09-versioning/version
+- name: github.com/sirupsen/logrus
+  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
 - name: golang.org/x/sys
-  version: 1e99a4f9d247b28c670884b9a8d6801f39a47b77
+  version: b47fdc937951267e2d980171881317deea47f29b
   subpackages:
   - unix
 testImports: []

--- a/practice/09-versioning/glide.yaml
+++ b/practice/09-versioning/glide.yaml
@@ -1,6 +1,7 @@
-package: github.com/rumyantseva/production-ready-microservices/practice/09-versioning
+package: github.com/shekodn/production-ready-microservices/practice/09-versioning
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^1.0.2
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+- package: github.com/rumyantseva/production-ready-microservices
+  subpackages:
+  - practice/09-versioning/version
+- package: github.com/sirupsen/logrus

--- a/practice/09-versioning/handlers_test.go
+++ b/practice/09-versioning/handlers_test.go
@@ -31,7 +31,7 @@ func TestHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedGreeting := "Processing URL /..."
+	expectedGreeting := "Repo: UNKNOWN, Commit: UNKNOWN, Version: UNKNOWN"
 	testingGreeting := strings.Trim(string(greeting), " \n")
 	if testingGreeting != expectedGreeting {
 		t.Fatalf(

--- a/practice/09-versioning/main.go
+++ b/practice/09-versioning/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/10-makefile/glide.lock
+++ b/practice/10-makefile/glide.lock
@@ -1,12 +1,18 @@
-hash: 52d732bbcddeae6f48f49fb3790a384274ad7bde41204b99743afc72b986e0ee
-updated: 2017-07-21T07:44:54.25932038+03:00
+hash: aadb2c966a55c3ae7f310cd3deca0a6bcad77773e95c9c199507293b48d71f30
+updated: 2019-06-20T11:49:24.023843-05:00
 imports:
 - name: github.com/julienschmidt/httprouter
-  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 348b672cd90d8190f8240323e372ecd1e66b59dc
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
+- name: github.com/rumyantseva/production-ready-microservices
+  version: 759ce485b6a1155db8a13b878c1e8ca87ff27607
+  subpackages:
+  - practice/10-makefile/version
+- name: github.com/sirupsen/logrus
+  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
 - name: golang.org/x/sys
-  version: 1e99a4f9d247b28c670884b9a8d6801f39a47b77
+  version: b47fdc937951267e2d980171881317deea47f29b
   subpackages:
   - unix
 testImports: []

--- a/practice/10-makefile/glide.yaml
+++ b/practice/10-makefile/glide.yaml
@@ -1,6 +1,7 @@
-package: github.com/rumyantseva/production-ready-microservices/practice/10-makefile
+package: github.com/shekodn/production-ready-microservices/practice/10-makefile
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^1.0.2
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+- package: github.com/rumyantseva/production-ready-microservices
+  subpackages:
+  - practice/10-makefile/version
+- package: github.com/sirupsen/logrus

--- a/practice/10-makefile/main.go
+++ b/practice/10-makefile/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/practice/11-healthcheck/glide.lock
+++ b/practice/11-healthcheck/glide.lock
@@ -1,12 +1,18 @@
-hash: 52d732bbcddeae6f48f49fb3790a384274ad7bde41204b99743afc72b986e0ee
-updated: 2017-07-21T07:44:54.25932038+03:00
+hash: 99202385c82c92333ef894f0cd2a12cd7f7015f744fc07113236498587e33c03
+updated: 2019-06-20T11:51:43.002003-05:00
 imports:
 - name: github.com/julienschmidt/httprouter
-  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
-- name: github.com/Sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: 348b672cd90d8190f8240323e372ecd1e66b59dc
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
+- name: github.com/rumyantseva/production-ready-microservices
+  version: 759ce485b6a1155db8a13b878c1e8ca87ff27607
+  subpackages:
+  - practice/11-healthcheck/version
+- name: github.com/sirupsen/logrus
+  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
 - name: golang.org/x/sys
-  version: 1e99a4f9d247b28c670884b9a8d6801f39a47b77
+  version: b47fdc937951267e2d980171881317deea47f29b
   subpackages:
   - unix
 testImports: []

--- a/practice/11-healthcheck/glide.yaml
+++ b/practice/11-healthcheck/glide.yaml
@@ -1,6 +1,7 @@
-package: github.com/rumyantseva/production-ready-microservices/practice/11-healthcheck
+package: github.com/shekodn/production-ready-microservices/practice/11-healthcheck
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^1.0.2
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+- package: github.com/rumyantseva/production-ready-microservices
+  subpackages:
+  - practice/11-healthcheck/version
+- package: github.com/sirupsen/logrus

--- a/practice/11-healthcheck/main.go
+++ b/practice/11-healthcheck/main.go
@@ -5,7 +5,7 @@ import (
 
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 )
 


### PR DESCRIPTION
This is in order to update an old _logrus_ dependency and should fix issue: #3 until chapter 11 (12 is missing)

For chapter 12, there is a dependency https://github.com/k8s-community/utils/blob/master/shutdown/shutdown.go that still uses the old logrus ```github.com/Sirupsen/logrus``` 

How should we proceed @rumyantseva ?